### PR TITLE
Support for special characters

### DIFF
--- a/rid.py
+++ b/rid.py
@@ -344,7 +344,7 @@ class RIDResults(object):
         self.word_count = 0
 
 
-WORD_REGEX = re.compile(r"[^a-zA-Z]+")
+WORD_REGEX = re.compile(r"\W+")
 
 
 def tokenize(string):


### PR DESCRIPTION
Some languages use characters that are outside the base ASCII character set.
While words with those characters appear in some international dictionaries,
those aren't currently properly handled by this program.

Example:
```
$ echo "J'ai regardé le café" | rid -d French\ RID.cat -e French\ RID.EXC
PROCESSUS PRIMAIRES:SENSATIONS:VUE                               1
    regard

[...]
```

Same thing in english:
```
echo "I watched the coffee" | rid
PRIMARY:SENSATION:VISION                                         1
    watched
PRIMARY:NEED:ORALITY                                             1
    coffee

[...]
```

This very simple change makes it handle special characters correctly:
```
echo "J'ai regardé le café" | rid -d French\ RID.cat -e French\ RID.EXC
PROCESSUS PRIMAIRES:SENSATIONS:VUE                               1
    regardé
PROCESSUS PRIMAIRES:BESOINS:ORALITÉ                              1
    café

[...]
```

To reproduce, I used the french dictionary from
https://www.kovcomp.co.uk/wordstat/RID.html

This is a breaking change for non-ASCII texts, although those weren't very
usable already.  so I don't think this is an issue.

This is also a breaking change for ASCII texts, as numbers will now be counted
as words, which will have an impact on the total word numbers. I think it is
acceptable, it keeps things simple, and is probably more correct (maybe those
should be counted, or maybe some languages use numbers in their words?).